### PR TITLE
fix: parser download thumbnail instead of video

### DIFF
--- a/src/parsers/DownloadParser.ts
+++ b/src/parsers/DownloadParser.ts
@@ -7,7 +7,7 @@ class DownloadParser implements IParser<DownloadResponse> {
     const thumb = dom.querySelector(".download-items__thumb img")?.attributes[
       "src"
     ];
-    const url = dom.querySelector(".download-items__btn a")?.attributes["href"];
+    const url = dom.querySelector(".download-items__btn:not(.dl-thumb) a")?.attributes["href"];
     return {
       thumb,
       url,


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/511ba6bb-cfd9-4f95-a1ed-048608a8f8c0)

Currently the downloader site gives us two buttons to download either thumb or video, but our parser always download thumbnail instead of video, so we just need to let the parser now video element should be it gets
